### PR TITLE
use the block source code printer for inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "biscuit-auth"
 version = "1.1.0"
-source = "git+https://github.com/CleverCloud/biscuit-rust?branch=master#e12d85820e23d5b4396d2c770231e45cd54f2a61"
+source = "git+https://github.com/CleverCloud/biscuit-rust?branch=master#2af460f2b20441b0235bd335b04804c1f2bccac8"
 dependencies = [
  "base64",
  "bytes",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -527,9 +527,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -678,6 +678,6 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,7 +486,16 @@ fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
 
     let biscuit = read_biscuit_from(&biscuit_from)?;
 
-    println!("{}", biscuit.print());
+    for i in 0..biscuit.block_count() {
+        if i == 0 {
+            println!("Authority block:");
+        } else {
+            println!("Block n°{}:", i);
+        }
+
+        println!("{}\n==========\n", biscuit.print_block_source(i).unwrap_or_else(String::new));
+    }
+
     let verifier_from = match (&inspect.verify_with, &inspect.verify_with_file) {
         (None, None) => None,
         (Some(str), None) => Some(DatalogInput::DatalogString(str.to_owned())),


### PR DESCRIPTION
Example usage:

```
[geal@lolcatho biscuit-cli]$ cargo run -- inspect --raw-input - < ../spec/samples/v1/test10_authority_rules.bc
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/biscuit inspect --raw-input -`
Authority block:
right(#authority, $1, #read) <- resource(#ambient, $1), owner(#ambient, $0, $1);
right(#authority, $1, #write) <- resource(#ambient, $1), owner(#ambient, $0, $1);

==========

Block n°1:
check if right(#authority, $0, $1), resource(#ambient, $0), operation(#ambient, $1);
check if resource(#ambient, $0), owner(#ambient, #alice, $0);

==========
```