### PR TITLE
Read datalog interactively with $EDITOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,8 +54,8 @@ dependencies = [
  "nom",
  "prost",
  "prost-types",
- "rand",
- "rand_core",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "regex",
  "sha2",
  "thiserror",
@@ -69,6 +69,7 @@ dependencies = [
  "biscuit-auth",
  "clap",
  "hex",
+ "tempfile",
 ]
 
 [[package]]
@@ -188,7 +189,7 @@ checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -233,6 +234,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -448,11 +460,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -462,7 +486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -471,7 +505,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -480,7 +523,25 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -499,6 +560,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "sha2"
@@ -541,6 +611,20 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand 0.8.4",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 biscuit-auth = { git = "https://github.com/CleverCloud/biscuit-rust", branch = "master" }
-hex = "0.4.3"
 clap = "3.0.0-beta.2"
+hex = "0.4.3"
+tempfile = "3.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,9 @@ fn read_stdin_bytes() -> Result<Vec<u8>, Box<dyn Error>> {
 }
 
 fn read_editor_string() -> Result<String, Box<dyn Error>> {
-    let file = tempfile::Builder::new().suffix(".datalog").tempfile()?;
+    let file = tempfile::Builder::new()
+        .suffix(".biscuit-datalog")
+        .tempfile()?;
     let path = &file.path();
 
     let editor = match env::var("EDITOR") {


### PR DESCRIPTION
`biscuit generate`, `biscuit attenuate` (and `biscuit verify`, optionally),
read datalog provided by the user. In addition to inline datalog, and datalog read from
a user-provided file (or stdin, for `biscuit generate`), this commit adds the possibility
of reading datalog from a temporary file created by the CLI, with $EDITOR opened to edit it,
exactly like with `git commit`.

Error management is crude, and EDITOR is defaulted to `vim` if not present, but it works.

The temporary file is given a ~`.datalog`~ `.biscuit-datalog` extension so that editor has a chance to enable
language support (eg syntax coloring). ~I'm not super happy with the extension, as the
datalog used by biscuit is not standard (because of its extensions, and of the use of
`<-` instead of the more common `:-` sigil for rules.~ The new extension is explicit, but a tad long.
Bikeshed away!

Here's a gif showing how it looks like with (really minimal) editor support.

![2021-07-26-13-51-53](https://user-images.githubusercontent.com/173299/126984622-bc526e44-ad4d-4483-b669-7accd426dad3.gif)
