### PR TITLE
Datalog error output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use biscuit_auth::{
     parser::{parse_block_source, parse_source},
     Authorizer, Biscuit, UnverifiedBiscuit, {KeyPair, PrivateKey, PublicKey},
 };
-use clap::{AppSettings, Parser};
+use clap::Parser;
 use std::env;
 use std::error::Error;
 use std::fmt;


### PR DESCRIPTION
 display more info when the authorizer check fails

The errors we are interested in are :
- failed datalog checks
- a deny policy matched
- no policy matched
- datalog computation was aborted (timeout, too many facts or iterations)

Note that the rust lib does not currently
- report when there are both failed checks and a deny policy matched. It seems that the failed checks take precedence;
- provide a pretty-printed version of the deny rule that matched (only its index)

```
biscuit inspect --raw-input ../biscuit/samples/v2/test13_block_rules.bc --public-key acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189 --verify-with 'time(2021-11-01T14:44:44Z); check if false; deny if true;'`
Authority block:
== Datalog ==
right("file1", "read");
right("file2", "read");

== Revocation id ==
893ff2daf44325f05849f581de561732094f14223d724202ce2f3d4058cead2ba238e4ef3a6b18f076f155e5e21ec30eded28f98d29979a39eb7f72da128a404

==========

Block n°1:
== Datalog ==
valid_date("file1") <- time($0), resource("file1"), $0 <= 2030-12-31T12:59:59+00:00;
valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59+00:00, !["file1"].contains($1);
check if valid_date($0), resource($0);

== Revocation id ==
3189fe4ccec73777fcb0a63fb497c4391bc967c1cc02ec409ae19e7e30fd2bfeb2c309e67c615bcae986a0de15a1a21b5623ccdab5afe36c11c539ac7e475202

==========

✅ Public key check succeeded 🔑
❌ Authorizer check failed 🛡️
The following checks failed:
Authorizer check: check if false
Block 1 check: check if valid_date($0), resource($0)
```