### PR TITLE
Better handle $EDITOR with arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "biscuit-auth",
  "clap",
  "hex",
+ "shell-words",
  "tempfile",
 ]
 
@@ -538,6 +539,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "signature"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ biscuit-auth = "2.0.0"
 clap = { version = "3.0.0-rc.7", features = ["color", "derive"] }
 hex = "0.4.3"
 tempfile = "3.2.0"
+shell-words = "^1.0.0"


### PR DESCRIPTION
Treat the $EDITOR environment variable as potentially having arguments, instead of just being a path to a binary.

This allows EDITOR="my-editor --some-param" without getting an error looking for a binary named "my-editor --some-param".

This commit brings in the [shell-words](https://crates.io/crates/shell-words) crate to parse out the editor arguments, which may or may not work well on Windows (the crate mentions parsing using unix rules). I looked at using `Exec::shell` from the [subprocess](https://crates.io/crates/subprocess) but this spawns a shell process and looked somewhat scarier.

Fixes #19.