### PR TITLE
Let `biscuit inspect` provide the current time during verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "biscuit-auth",
+ "chrono",
  "clap",
  "hex",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 atty = "0.2.14"
 biscuit-auth = "2.0.0"
 clap = { version = "3.0.0-rc.7", features = ["color", "derive"] }
+chrono = "^0.4"
 hex = "0.4.3"
 tempfile = "3.2.0"
 shell-words = "^1.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,4 +145,7 @@ pub struct Inspect {
         conflicts_with("verify-interactive")
     )]
     pub verify_with: Option<String>,
+    /// Include the current time in the verifier facts
+    #[clap(long)]
+    pub include_time: bool,
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -2,6 +2,7 @@ use biscuit_auth::{
     builder::Policy,
     error::{FailedCheck, Logic, MatchedPolicy, RunLimit, Token},
 };
+use chrono::offset::Utc;
 use std::error::Error;
 use std::path::PathBuf;
 
@@ -93,6 +94,11 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
         if let Some(auth_from) = authorizer_from {
             let mut authorizer_builder = biscuit.authorizer()?;
             read_authorizer_from(&auth_from, &mut authorizer_builder)?;
+            if inspect.include_time {
+                let now = Utc::now().to_rfc3339();
+                let time_fact = format!("time({})", now);
+                authorizer_builder.add_fact(time_fact.as_ref())?;
+            }
             let (_, _, _, policies) = authorizer_builder.dump();
             let authorizer_result = authorizer_builder.authorize();
             match authorizer_result {


### PR DESCRIPTION
This makes TTL checks easier.
clap does not allow yet making an option depend on one of other
options, so the flag is ignored if there is no verifier provided.

See #11