### PR TITLE
display error and exit(1) instead of panicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::io::Write;
 use std::io::{self};
 use std::path::PathBuf;
+use std::process;
 
 mod cli;
 mod errors;
@@ -190,5 +191,11 @@ fn handle_attenuate(attenuate: &Attenuate) -> Result<(), Box<dyn Error>> {
 
 pub fn main() {
     let opts: Opts = Opts::parse();
-    let _ = handle_command(&opts.subcmd).unwrap();
+    match handle_command(&opts.subcmd) {
+        Ok(()) => process::exit(0),
+        Err(e) => {
+            eprintln!("[Error] {}", &e);
+            process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
This improves the UX a bit (a panic looks like an unexpected error, even though errors are properly handled throughout the program).

See #24

Before

```
❯ echo "user(1234);" | biscuit generate --private-key $(biscuit keypair --only-private-key) - | biscuit inspect --raw-input -
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Format(DeserializationError("deserialization error: DecodeError { description: \"invalid wire type value: 7\", stack: [] }"))', src/main.rs:194:42
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After

```
❯ echo "user(1234);" | biscuit generate --private-key $(biscuit keypair --only-private-key) - | biscuit inspect --raw-input -
[Error] error deserializing or verifying the token
```