### PR TITLE
Sealing biscuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@
 - configurable run limitations (#34)
 - rename `verifier` to `authorizer` (#36)
 - support for generating and inspecting authorizer snapshots (#33)
+- support for sealing biscuits (#26)
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,8 @@ pub enum SubCommand {
     GenerateThirdPartyBlock(GenerateThirdPartyBlock),
     #[clap()]
     AppendThirdPartyBlock(AppendThirdPartyBlock),
+    #[clap()]
+    Seal(Seal),
 }
 
 /// Create and manipulate key pairs
@@ -363,4 +365,18 @@ pub struct GenerateThirdPartyBlock {
         value_name = "key=value::type",
     )]
     pub param: Vec<Param>,
+}
+
+/// Seal a token, preventing further attenuation
+#[derive(Parser)]
+pub struct Seal {
+    /// Read the biscuit from the given file (or use `-` to read from stdin)
+    #[clap(parse(from_os_str))]
+    pub biscuit_file: PathBuf,
+    /// Read the biscuit raw bytes directly, with no base64 parsing
+    #[clap(long)]
+    pub raw_input: bool,
+    /// Output the biscuit raw bytes directly, with no base64 encoding
+    #[clap(long)]
+    pub raw_output: bool,
 }


### PR DESCRIPTION
It works okay, the only little issue is that `biscuit-rust` seems to report an incorrect error variant when trying to append a block to a sealed token: instead of `AppendOnSeal`, we get `AlreadySealed`.

Not a blocker, imo.