### PR TITLE
Support for third-party blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,8 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "biscuit-auth"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbb36e3ce26459005ce53ae70777060bf5f207f4490e62e0b01869df293ef21"
+version = "2.2.0"
+source = "git+https://github.com/biscuit-auth/biscuit-rust#523b8d4cd6c8371eceff8172c29ae6fe411c09d0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -53,6 +52,7 @@ dependencies = [
  "nom",
  "prost",
  "prost-types",
+ "quote",
  "rand",
  "rand_core",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "biscuit-auth"
 version = "2.2.0"
-source = "git+https://github.com/biscuit-auth/biscuit-rust#523b8d4cd6c8371eceff8172c29ae6fe411c09d0"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#508f71c0ef4fd5125e5cc9b2a84df2a12af81f9a"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "biscuit-auth"
 version = "2.2.0"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#0007227d01e93b9dc08b5988b8ce1a3c04b10e12"
+source = "git+https://github.com/biscuit-auth/biscuit-rust#df9b0cf5dc6c342f5c1be29e9d32cf0922d7a256"
 dependencies = [
  "base64",
  "biscuit-parser",
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "biscuit-parser"
 version = "0.1.0"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#0007227d01e93b9dc08b5988b8ce1a3c04b10e12"
+source = "git+https://github.com/biscuit-auth/biscuit-rust#df9b0cf5dc6c342f5c1be29e9d32cf0922d7a256"
 dependencies = [
  "hex",
  "nom",
@@ -101,7 +101,7 @@ dependencies = [
 [[package]]
 name = "biscuit-quote"
 version = "0.1.0"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#0007227d01e93b9dc08b5988b8ce1a3c04b10e12"
+source = "git+https://github.com/biscuit-auth/biscuit-rust#df9b0cf5dc6c342f5c1be29e9d32cf0922d7a256"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",
@@ -723,9 +723,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signature"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.53"
+name = "android_system_properties"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "atty"
@@ -30,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -43,22 +52,23 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "biscuit-auth"
 version = "2.2.0"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#508f71c0ef4fd5125e5cc9b2a84df2a12af81f9a"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#0007227d01e93b9dc08b5988b8ce1a3c04b10e12"
 dependencies = [
  "base64",
+ "biscuit-parser",
+ "biscuit-quote",
  "ed25519-dalek",
  "getrandom",
  "hex",
  "nom",
  "prost",
  "prost-types",
- "quote",
  "rand",
  "rand_core",
  "regex",
  "sha2",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.13",
  "zeroize",
 ]
 
@@ -77,6 +87,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "biscuit-parser"
+version = "0.1.0"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#0007227d01e93b9dc08b5988b8ce1a3c04b10e12"
+dependencies = [
+ "hex",
+ "nom",
+ "quote",
+ "thiserror",
+ "time 0.3.13",
+]
+
+[[package]]
+name = "biscuit-quote"
+version = "0.1.0"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=3rd-party#0007227d01e93b9dc08b5988b8ce1a3c04b10e12"
+dependencies = [
+ "biscuit-parser",
+ "proc-macro-error",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,9 +138,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cfg-if"
@@ -111,29 +150,31 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -141,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -153,19 +194,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.1"
+name = "clap_lex"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest",
@@ -185,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
 ]
@@ -208,24 +264,24 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -244,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -270,10 +326,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "indexmap"
-version = "1.8.0"
+name = "iana-time-zone"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -299,9 +368,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "js-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -311,15 +389,24 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "minimal-lexical"
@@ -329,13 +416,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -375,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -385,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -408,21 +494,27 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_threads"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -432,12 +524,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parse_duration"
@@ -482,11 +571,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -524,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -574,18 +663,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -594,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -609,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 
 [[package]]
 name = "sha2"
@@ -628,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signature"
@@ -652,13 +741,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -689,33 +778,33 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -735,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa",
  "libc",
@@ -751,10 +840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "version_check"
@@ -773,6 +868,60 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"
@@ -807,18 +956,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.5.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 atty = "0.2.14"
-biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", revision = "523b8d4cd6c8371eceff8172c29ae6fe411c09d0"}
+biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "3rd-party" }
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 atty = "0.2.14"
-biscuit-auth = "2.1.0"
+biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", revision = "523b8d4cd6c8371eceff8172c29ae6fe411c09d0"}
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 atty = "0.2.14"
-biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "3rd-party" }
+biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", revision = "df9b0cf5dc6c342f5c1be29e9d32cf0922d7a256" }
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"

--- a/src/input.rs
+++ b/src/input.rs
@@ -151,13 +151,13 @@ pub fn read_authority_from(
     })?;
 
     for (fact_str, _) in result.facts {
-        builder.add_authority_fact(fact_str)?;
+        builder.add_fact(fact_str)?;
     }
     for (rule_str, _) in result.rules {
-        builder.add_authority_rule(rule_str)?;
+        builder.add_rule(rule_str)?;
     }
     for (check_str, _) in result.checks {
-        builder.add_authority_check(check_str)?;
+        builder.add_check(check_str)?;
     }
 
     if let Some(ctx) = context {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -60,11 +60,20 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
     let biscuit = read_biscuit_from(&biscuit_from)?;
 
     let content_revocation_ids = biscuit.revocation_identifiers();
+    let external_keys = biscuit.external_public_keys();
     for i in 0..biscuit.block_count() {
         if i == 0 {
             println!("Authority block:");
         } else {
-            println!("Block n°{}:", i);
+            if let Some(Some(epk)) = external_keys.get(i) {
+                println!(
+                    "Block n°{}, (third party, signed by {}):",
+                    i,
+                    hex::encode(&epk)
+                );
+            } else {
+                println!("Block n°{}:", i);
+            }
         }
 
         println!("== Datalog ==");

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -68,10 +68,7 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
         }
 
         println!("== Datalog ==");
-        println!(
-            "{}",
-            biscuit.print_block_source(i).unwrap_or_else(String::new)
-        );
+        println!("{}", biscuit.print_block_source(i)?);
 
         println!("== Revocation id ==");
         let content_id = content_revocation_ids

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -54,7 +54,7 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
     };
 
     if let Some(vf) = &authorizer_from {
-        ensure_no_input_conflict(&vf, &biscuit_from)?;
+        ensure_no_input_conflict(vf, &biscuit_from)?;
     }
 
     let biscuit = read_biscuit_from(&biscuit_from)?;
@@ -64,16 +64,14 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
     for i in 0..biscuit.block_count() {
         if i == 0 {
             println!("Authority block:");
+        } else if let Some(Some(epk)) = external_keys.get(i) {
+            println!(
+                "Block n°{}, (third party, signed by {}):",
+                i,
+                hex::encode(&epk)
+            );
         } else {
-            if let Some(Some(epk)) = external_keys.get(i) {
-                println!(
-                    "Block n°{}, (third party, signed by {}):",
-                    i,
-                    hex::encode(&epk)
-                );
-            } else {
-                println!("Block n°{}:", i);
-            }
+            println!("Block n°{}:", i);
         }
 
         println!("== Datalog ==");
@@ -145,12 +143,12 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<(), Box<dyn Error>> {
 fn display_logic_error(policies: &[Policy], e: &Logic) {
     match e {
         Logic::Unauthorized { policy, checks } => {
-            display_matched_policy(policies, &policy);
-            display_failed_checks(&checks);
+            display_matched_policy(policies, policy);
+            display_failed_checks(checks);
         }
         Logic::NoMatchingPolicy { checks } => {
             println!("No policy matched");
-            display_failed_checks(&checks);
+            display_failed_checks(checks);
         }
         e => println!("An execution error happened during authorization: {:?}", &e),
     }
@@ -176,7 +174,7 @@ fn display_matched_policy(policies: &[Policy], policy: &MatchedPolicy) {
 }
 
 fn display_failed_checks(checks: &Vec<FailedCheck>) {
-    if checks.len() > 0 {
+    if !checks.is_empty() {
         println!("The following checks failed:");
     }
     for c in checks {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,13 @@ fn handle_command(cmd: &SubCommand) -> Result<(), Box<dyn Error>> {
         SubCommand::Inspect(inspect) => handle_inspect(&inspect),
         SubCommand::Generate(generate) => handle_generate(&generate),
         SubCommand::Attenuate(attenuate) => handle_attenuate(&attenuate),
+        SubCommand::GenerateRequest(generate_request) => handle_generate_request(&generate_request),
+        SubCommand::GenerateThirdPartyBlock(generate_third_party_block) => {
+            handle_generate_third_party_block(&generate_third_party_block)
+        }
+        SubCommand::AppendThirdPartyBlock(append_third_party_block) => {
+            handle_append_third_party_block(&append_third_party_block)
+        }
     }
 }
 
@@ -181,6 +188,152 @@ fn handle_attenuate(attenuate: &Attenuate) -> Result<(), Box<dyn Error>> {
 
     let new_biscuit = biscuit.append(block_builder)?;
     let encoded = if attenuate.raw_output {
+        new_biscuit.to_vec()?
+    } else {
+        new_biscuit.to_base64()?.into_bytes()
+    };
+    let _ = io::stdout().write_all(&encoded);
+    Ok(())
+}
+
+fn handle_generate_request(generate_request: &GenerateRequest) -> Result<(), Box<dyn Error>> {
+    let biscuit_format = if generate_request.raw_input {
+        BiscuitFormat::RawBiscuit
+    } else {
+        BiscuitFormat::Base64Biscuit
+    };
+
+    let biscuit_from = if generate_request.biscuit_file == PathBuf::from("-") {
+        BiscuitBytes::FromStdin(biscuit_format)
+    } else {
+        BiscuitBytes::FromFile(biscuit_format, generate_request.biscuit_file.clone())
+    };
+
+    let biscuit = read_biscuit_from(&biscuit_from)?;
+
+    let request = biscuit.third_party_request()?;
+
+    let encoded = if generate_request.raw_output {
+        request.serialize()?
+    } else {
+        request.serialize_base64()?
+    };
+    let _ = io::stdout().write_all(&encoded);
+    Ok(())
+}
+
+fn handle_generate_third_party_block(
+    generate_third_party_block: &GenerateThirdPartyBlock,
+) -> Result<(), Box<dyn Error>> {
+    let block_format = if generate_third_party_block.raw_input {
+        BiscuitFormat::RawBiscuit
+    } else {
+        BiscuitFormat::Base64Biscuit
+    };
+
+    let request_from = if generate_third_party_block.request_file == PathBuf::from("-") {
+        BiscuitBytes::FromStdin(block_format)
+    } else {
+        BiscuitBytes::FromFile(
+            block_format,
+            generate_third_party_block.request_file.clone(),
+        )
+    };
+
+    let block_from = match (
+        &generate_third_party_block.block_file,
+        &generate_third_party_block.block,
+    ) {
+        (Some(file), None) => DatalogInput::FromFile(file.to_path_buf()),
+        (None, Some(str)) => DatalogInput::DatalogString(str.to_owned()),
+        (None, None) => DatalogInput::FromEditor,
+        // the other combinations are prevented by clap
+        _ => unreachable!(),
+    };
+
+    ensure_no_input_conflict(&block_from, &request_from)?;
+
+    let private_key: Result<PrivateKey, Box<dyn Error>> = read_private_key_from(&match (
+        &generate_third_party_block.private_key,
+        &generate_third_party_block.private_key_file,
+        &generate_third_party_block.raw_private_key,
+    ) {
+        (Some(hex_string), None, false) => KeyBytes::HexString(hex_string.to_owned()),
+        (None, Some(file), true) => KeyBytes::FromFile(KeyFormat::RawBytes, file.to_path_buf()),
+        (None, Some(file), false) => KeyBytes::FromFile(KeyFormat::HexKey, file.to_path_buf()),
+        // the other combinations are prevented by clap
+        _ => unreachable!(),
+    });
+
+    let mut request = read_request_from(&request_from)?;
+
+    read_block_from(
+        &block_from,
+        &generate_third_party_block.context,
+        &mut request,
+    )?;
+
+    if let Some(duration) = generate_third_party_block.add_ttl {
+        let expiration = Utc::now() + duration;
+        request.add_check::<&str>(&format!(
+            "check if time($t), $t < {}",
+            &expiration.to_rfc3339()
+        ))?;
+    }
+
+    let encoded = if generate_third_party_block.raw_output {
+        request.create_response(private_key?)?
+    } else {
+        request.create_response_base64(private_key?)?
+    };
+    let _ = io::stdout().write_all(&encoded);
+    Ok(())
+}
+
+fn handle_append_third_party_block(
+    append_third_party_block: &AppendThirdPartyBlock,
+) -> Result<(), Box<dyn Error>> {
+    let biscuit_format = if append_third_party_block.raw_input {
+        BiscuitFormat::RawBiscuit
+    } else {
+        BiscuitFormat::Base64Biscuit
+    };
+
+    let biscuit_from = if append_third_party_block.biscuit_file == PathBuf::from("-") {
+        BiscuitBytes::FromStdin(biscuit_format)
+    } else {
+        BiscuitBytes::FromFile(
+            biscuit_format,
+            append_third_party_block.biscuit_file.clone(),
+        )
+    };
+
+    let block_file_format = if append_third_party_block.raw_block_contents {
+        BiscuitFormat::RawBiscuit
+    } else {
+        BiscuitFormat::Base64Biscuit
+    };
+
+    let block_from = match (
+        &append_third_party_block.block_contents_file,
+        &append_third_party_block.block_contents,
+    ) {
+        (Some(file), None) if file == &PathBuf::from("-") => {
+            BiscuitBytes::FromStdin(block_file_format)
+        }
+        (Some(file), None) => BiscuitBytes::FromFile(block_file_format, file.to_path_buf()),
+        (None, Some(str)) => BiscuitBytes::Base64String(str.to_owned()),
+        // the other combinations are prevented by clap
+        _ => unreachable!(),
+    };
+
+    ensure_no_input_conflict_third_party(&block_from, &biscuit_from)?;
+
+    let biscuit = read_biscuit_from(&biscuit_from)?;
+
+    let new_biscuit = append_third_party_from(&biscuit, &block_from)?;
+
+    let encoded = if append_third_party_block.raw_output {
         new_biscuit.to_vec()?
     } else {
         new_biscuit.to_base64()?.into_bytes()

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,16 +21,16 @@ use inspect::*;
 
 fn handle_command(cmd: &SubCommand) -> Result<(), Box<dyn Error>> {
     match cmd {
-        SubCommand::KeyPairCmd(key_pair_cmd) => handle_keypair(&key_pair_cmd),
-        SubCommand::Inspect(inspect) => handle_inspect(&inspect),
-        SubCommand::Generate(generate) => handle_generate(&generate),
-        SubCommand::Attenuate(attenuate) => handle_attenuate(&attenuate),
-        SubCommand::GenerateRequest(generate_request) => handle_generate_request(&generate_request),
+        SubCommand::KeyPairCmd(key_pair_cmd) => handle_keypair(key_pair_cmd),
+        SubCommand::Inspect(inspect) => handle_inspect(inspect),
+        SubCommand::Generate(generate) => handle_generate(generate),
+        SubCommand::Attenuate(attenuate) => handle_attenuate(attenuate),
+        SubCommand::GenerateRequest(generate_request) => handle_generate_request(generate_request),
         SubCommand::GenerateThirdPartyBlock(generate_third_party_block) => {
-            handle_generate_third_party_block(&generate_third_party_block)
+            handle_generate_third_party_block(generate_third_party_block)
         }
         SubCommand::AppendThirdPartyBlock(append_third_party_block) => {
-            handle_append_third_party_block(&append_third_party_block)
+            handle_append_third_party_block(append_third_party_block)
         }
     }
 }
@@ -61,7 +61,7 @@ fn handle_keypair(key_pair_cmd: &KeyPairCmd) -> Result<(), Box<dyn Error>> {
     };
 
     let private_key: Option<PrivateKey> = if let Some(f) = private_key_from {
-        Some(read_private_key_from(&f)?)
+        Some(read_private_key_from(f)?)
     } else {
         None
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use biscuit_auth::{
+    builder::BlockBuilder,
     Biscuit, {KeyPair, PrivateKey},
 };
 use chrono::Utc;
@@ -174,7 +175,7 @@ fn handle_attenuate(attenuate: &Attenuate) -> Result<(), Box<dyn Error>> {
     ensure_no_input_conflict(&block_from, &biscuit_from)?;
 
     let biscuit = read_biscuit_from(&biscuit_from)?;
-    let mut block_builder = biscuit.create_block();
+    let mut block_builder = BlockBuilder::new();
 
     read_block_from(&block_from, &attenuate.context, &mut block_builder)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,17 +120,17 @@ fn handle_generate(generate: &Generate) -> Result<(), Box<dyn Error>> {
     });
 
     let root = KeyPair::from(private_key?);
-    let mut builder = Biscuit::builder(&root);
+    let mut builder = Biscuit::builder();
     read_authority_from(&authority_from, &generate.context, &mut builder)?;
 
     if let Some(duration) = generate.add_ttl {
         let expiration = Utc::now() + duration;
-        builder.add_authority_check::<&str>(&format!(
+        builder.add_check::<&str>(&format!(
             "check if time($t), $t < {}",
             &expiration.to_rfc3339()
         ))?;
     }
-    let biscuit = builder.build().expect("Error building biscuit"); // todo display error
+    let biscuit = builder.build(&root).expect("Error building biscuit"); // todo display error
     let encoded = if generate.raw {
         biscuit.to_vec().expect("Error serializing token")
     } else {


### PR DESCRIPTION
- generate third-party blocks (request / contents)
- display information about third-party blocks

# New commands:

```
biscuit generate-request test23_execution_scope.bc --raw-input > test-request
biscuit generate-third-party-block --private-key-file test-external-pk --block 'toto(1,2,3);' test-request > test-block-contents
biscuit append-third-party-block --block-contents-file test-block-contents test23_execution_scope.bc --raw-input
```

# New output

```
❯ biscuit append-third-party-block --block-contents-file test-block-contents ../biscuit-haskell/biscuit/test/samples/v2/test23_execution_scope.bc --raw-input | biscuit inspect -
Authority block:
== Datalog ==
authority_fact(1);

== Revocation id ==
6a3606836bc63b858f96ce5000c9bead8eda139ab54679a2a8d7a9984c2e5d864b93280acc1b728bed0be42b5b1c3be10f48a13a4dbd05fd5763de5be3855108

==========

Block n°1:
== Datalog ==
block1_fact(1);

== Revocation id ==
5f1468fc60999f22c4f87fa088a83961188b4e654686c5b04bdc977b9ff4666d51a3d8be5594f4cef08054d100f31d1637b50bb394de7cccafc643c9b650390b

==========

Block n°2:
== Datalog ==
check if authority_fact($var);
check if block1_fact($var);

== Revocation id ==
3eda05ddb65ee90d715cefc046837c01de944d8c4a7ff67e3d9a9d8470b5e214a20a8b9866bfe5e0d385e530b75ec8fcfde46b7dd6d4d6647d1e955c9d2fb90d

==========

Block n°3, (third party, signed by 84ffe21d3da5433c749f7a083fddc34fc91c78f23cfb04d4fdc33a994fe46a2c):
== Datalog ==
authority_fact(1, 2, 3);

== Revocation id ==
e4e372056e4331d6557db98b1577835de19467809cb062c9b7fce13d605670e4521344dd83fafe09d2a26024e9952de02d4e3b3ac8ddd760a515278e26102702

==========

🙈 Public key check skipped 🔑
🙈 Datalog check skipped 🛡️
```