### PR TITLE
Fix mismatched types errors after pull modifications

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,11 +67,11 @@ fn handle_keypair(key_pair_cmd: &KeyPairCmd) -> Result<()> {
     };
 
     let key_pair = if let Some(private) = private_key {
-        KeyPair::from(private)
+        KeyPair::from(&private)
     } else {
         KeyPair::new()
     };
-
+    
     match (
         &key_pair_cmd.only_private_key,
         &key_pair_cmd.raw_private_key_output,
@@ -127,7 +127,7 @@ fn handle_generate(generate: &Generate) -> Result<()> {
         _ => unreachable!(),
     });
 
-    let root = KeyPair::from(private_key?);
+    let root = KeyPair::from(&private_key?);
     let mut builder = Biscuit::builder();
     read_authority_from(
         &authority_from,
@@ -285,7 +285,7 @@ fn handle_generate_third_party_block(
         builder.check_expiration_date(expiration.into());
     }
 
-    let block = request.create_block(private_key?, builder)?;
+    let block = request.create_block(&private_key?, builder)?;
 
     let encoded = if generate_third_party_block.raw_output {
         block.serialize()?


### PR DESCRIPTION
Found these errors after updating and re-installing.

Maybe something has changed in biscuit-auth...
I suggest a humble fix.

```
error[E0308]: mismatched types
  --> src/main.rs:70:23
   |
70 |         KeyPair::from(private)
   |         ------------- ^^^^^^^
   |         |             |
   |         |             expected `&PrivateKey`, found struct `PrivateKey`
   |         |             help: consider borrowing here: `&private`
   |         arguments to this function are incorrect
   |
note: associated function defined here
  --> /Users/allema_s/.cargo/git/checkouts/biscuit-rust-18543cf52e92de67/65e6f86/biscuit-auth/src/crypto/mod.rs:35:12
   |
35 |     pub fn from(key: &PrivateKey) -> Self {
   |            ^^^^

error[E0308]: `?` operator has incompatible types
   --> src/main.rs:130:30
    |
130 |     let root = KeyPair::from(private_key?);
    |                              ^^^^^^^^^^^^
    |                              |
    |                              expected `&PrivateKey`, found struct `PrivateKey`
    |                              help: consider borrowing here: `&private_key?`
    |
    = note: `?` operator cannot convert from `PrivateKey` to `&PrivateKey`

error[E0308]: `?` operator has incompatible types
   --> src/main.rs:288:38
    |
288 |     let block = request.create_block(private_key?, builder)?;
    |                                      ^^^^^^^^^^^^
    |                                      |
    |                                      expected `&PrivateKey`, found struct `PrivateKey`
    |                                      help: consider borrowing here: `&private_key?`
    |
    = note: `?` operator cannot convert from `PrivateKey` to `&PrivateKey`
 ```