### PR TITLE
s/verify/authorize/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,8 +51,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "biscuit-auth"
-version = "3.0.0-alpha4"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=main#676e32fd4071dd2f0ee0f76807f3ca53dd877c89"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a1439f6aa59801e9e061cd8c0ad44fb04271aad581d948b2c690dbc0376f6"
 dependencies = [
  "base64",
  "biscuit-parser",
@@ -91,8 +92,9 @@ dependencies = [
 
 [[package]]
 name = "biscuit-parser"
-version = "0.1.0-alpha4"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=main#676e32fd4071dd2f0ee0f76807f3ca53dd877c89"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a478329b2b23038692ea5b792b99984a5128ea644a35a58f647dc5554c3a5b2"
 dependencies = [
  "hex",
  "nom",
@@ -104,8 +106,9 @@ dependencies = [
 
 [[package]]
 name = "biscuit-quote"
-version = "0.2.0-alpha5"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=main#676e32fd4071dd2f0ee0f76807f3ca53dd877c89"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82c219bdfbbb102f3899b90cae4f04599a8be392234e998b94a25296c06bf41"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 #biscuit-auth = { path = "../biscuit-rust/biscuit-auth" }
 atty = "0.2.14"
-biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "main" }
+biscuit-auth = "3.0.0"
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,50 +218,53 @@ pub struct Inspect {
     /// Read the public key raw bytes directly
     #[clap(long, requires("public-key-file"), conflicts_with("public-key"))]
     pub raw_public_key: bool,
-    /// Open $EDITOR to provide a authorizer.
+    /// Open $EDITOR to provide an authorizer.
     #[clap(
         long,
-        conflicts_with("verify-with"),
-        conflicts_with("verify-with-file")
+        alias("verify-interactive"),
+        conflicts_with("authorize-with"),
+        conflicts_with("authorize-with-file")
     )]
-    pub verify_interactive: bool,
-    /// Verify the biscuit with the provided authorizer.
+    pub authorize_interactive: bool,
+    /// Authorize the biscuit with the provided authorizer.
     #[clap(
         long,
-        conflicts_with("verify-with"),
-        conflicts_with("verify-interactive")
+        alias("verify-with-file"),
+        conflicts_with("authorize-with"),
+        conflicts_with("authorize-interactive")
     )]
-    pub verify_with_file: Option<PathBuf>,
-    /// Verify the biscuit with the provided authorizer
+    pub authorize_with_file: Option<PathBuf>,
+    /// Authorize the biscuit with the provided authorizer
     #[clap(
         long,
-        conflicts_with("verify-with-file"),
-        conflicts_with("verify-interactive")
+        alias("verify-with"),
+        conflicts_with("authorize-with-file"),
+        conflicts_with("authorize-interactive")
     )]
-    pub verify_with: Option<String>,
+    pub authorize_with: Option<String>,
     /// Configure the maximum amount of facts that can be generated
     /// before aborting evaluation
     #[clap(
         long,
-        requires("verify-with"),
-        requires("verify-interactive"),
-        requires("verify-with-file")
+        requires("authorize-with"),
+        requires("authorize-interactive"),
+        requires("authorize-with-file")
     )]
     pub max_facts: Option<u64>,
     /// Configure the maximum amount of iterations before aborting
     /// evaluation
     #[clap(
         long,
-        requires("verify-with"),
-        requires("verify-interactive"),
-        requires("verify-with-file")
+        requires("authorize-with"),
+        requires("authorize-interactive"),
+        requires("authorize-with-file")
     )]
     pub max_iterations: Option<u64>,
     #[clap(
         long,
-        requires("verify-with"),
-        requires("verify-interactive"),
-        requires("verify-with-file"),
+        requires("authorize-with"),
+        requires("authorize-interactive"),
+        requires("authorize-with-file"),
         parse(try_from_str = parse_duration)
     )]
     /// Configure the maximum evaluation duration before aborting
@@ -274,9 +277,9 @@ pub struct Inspect {
         long,
         value_parser = clap::builder::ValueParser::new(parse_param),
         value_name = "key=value::type",
-        requires("verify-with"),
-        requires("verify-interactive"),
-        requires("verify-with-file")
+        requires("authorize-with"),
+        requires("authorize-interactive"),
+        requires("authorize-with-file")
     )]
     pub param: Vec<Param>,
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -42,9 +42,9 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<()> {
     };
 
     let authorizer_from = match (
-        &inspect.verify_interactive,
-        &inspect.verify_with,
-        &inspect.verify_with_file,
+        &inspect.authorize_interactive,
+        &inspect.authorize_with,
+        &inspect.authorize_with_file,
     ) {
         (false, None, None) => None,
         (true, None, None) => Some(DatalogInput::FromEditor),


### PR DESCRIPTION
Fixes #35 

This follows the global renaming that was already done in the rust and haskell libraries.
Verification is about checking cryptographic signatures. Authorization is about performing datalog checks.

The old flags are still provided as aliases so that existing scripts don't break, but they are not displayed in the contextual help.