### PR TITLE
generate: allow setting a root key id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Not released yet
+
+- support for viewing and setting root key ids (#41)
+
 # `0.3.0`
 
 - better errors (#25, #28)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "biscuit-auth"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47033e72ae01c3bea9385503636ba8cf54083bd52df80eccee088f806d7a0b42"
+checksum = "3d1e91dedc0523e4ff74633d4bdac7251e40e0759f3e85f5f7995ff3c095c281"
 dependencies = [
  "base64",
  "biscuit-parser",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "biscuit-parser"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a478329b2b23038692ea5b792b99984a5128ea644a35a58f647dc5554c3a5b2"
+checksum = "f6f2fea7264a5bff6f3444b3b05da27ad332427f5267435e2efabaf0476e45bf"
 dependencies = [
  "hex",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 atty = "0.2.14"
-biscuit-auth = "3.1.0"
+biscuit-auth = "3.2.0"
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,9 @@ pub struct Generate {
     /// Read the authority block from the given file (or use `-` to read from stdin). If omitted, an interactive $EDITOR will be opened.
     #[clap(parse(from_os_str))]
     pub authority_file: Option<PathBuf>,
+    /// Provide a root key id, as a hint for public key selection
+    #[clap(long)]
+    pub root_key_id: Option<u32>,
     /// Provide a value for a datalog parameter
     #[clap(
         long,

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -73,7 +73,11 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<()> {
     let external_keys = biscuit.external_public_keys();
     for i in 0..biscuit.block_count() {
         if i == 0 {
-            println!("Authority block:");
+            if let Some(root_key_id) = biscuit.root_key_id() {
+                println!("Authority block (root key identifier: {}):", &root_key_id);
+            } else {
+                println!("Authority block:");
+            }
         } else if let Some(Some(epk)) = external_keys.get(i) {
             println!(
                 "Block n°{}, (third party, signed by {}):",

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,9 @@ fn handle_generate(generate: &Generate) -> Result<()> {
     if let Some(ttl) = &generate.add_ttl {
         builder.check_expiration_date(ttl.to_datetime().into());
     }
+    if let Some(root_key_id) = &generate.root_key_id {
+        builder.set_root_key_id(*root_key_id);
+    }
     let biscuit = builder.build(&root).expect("Error building biscuit"); // todo display error
     let encoded = if generate.raw {
         biscuit.to_vec().expect("Error serializing token")


### PR DESCRIPTION
```
biscuit-cli on  root-key-id [$?] is 📦 v0.3.0 via 🦀 v1.68.1
❯ echo 'toto(true)'|biscuit generate --private-key-file private.key --root-key-id 1 - | biscuit inspect -
Open biscuit
Authority block (root key identifier: 1):
== Datalog ==
toto(true);

== Revocation id ==
1d888c544b44172b8262328cb2b76fc6512143a0984bb0c25f289007cd7b4268990d99aedff3a2ca06c0025ed48574401d7eca8467ed354198bd452e020d7e0c

==========

🙈 Public key check skipped 🔑
🙈 Datalog check skipped 🛡️
```