### PR TITLE
Improve parameter substitution syntax

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::fs::{self, File};
 use std::path::Path;
 use std::process;
 
-
 fn main() {
     // OUT_DIR is set by Cargo and it's where any additional build artifacts
     // are written.
@@ -25,4 +24,3 @@ fn main() {
         panic!("failed to write {}: {}", stamp_path.display(), err);
     }
 }
-

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,11 +125,13 @@ pub struct Generate {
     /// Provide a root key id, as a hint for public key selection
     #[clap(long)]
     pub root_key_id: Option<u32>,
-    /// Provide a value for a datalog parameter
+    /// Provide a value for a datalog parameter. `type` is optional and defaults to `string`. Possible types are pubkey, integer, date, bytes or bool.
+    /// `pubkey` takes a hex-encoded ed25519 key, without the `ed25519/` prefix
+    /// `bytes` takes a hex-encoded byte string, without the `hex:prefix`
     #[clap(
         long,
         value_parser = clap::builder::ValueParser::new(parse_param),
-        value_name = "key=value::type"
+        value_name = "key=value[::type]"
     )]
     pub param: Vec<Param>,
     /// Output the biscuit raw bytes directly, with no base64 encoding

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,49 +14,68 @@ pub enum Param {
 
 fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
     use std::io::{Error, ErrorKind};
-    let (name, value) = (kv.split_once('=').ok_or_else(|| Error::new(
+    let (binding, value) = (kv.split_once('=').ok_or_else(|| Error::new(
         ErrorKind::Other,
-        "Params must be `key=value` or `key=value::type` where type is pubkey, integer, date, bytes or bool",
+        "Params must be `key=value` or `key:type=value` where type is pubkey, string, integer, date, bytes or bool.",
     )))?;
-    if let Some(encoded) = value.strip_suffix("::pubkey") {
+
+    let (name, annotation) = match binding.rsplit_once(':') {
+        None => (binding, None),
+        Some((name, annotation)) => (name, Some(annotation)),
+    };
+
+    if annotation == Some("pubkey") {
+        let hex_key = value.strip_prefix("ed25519/").ok_or_else(|| Error::new(
+        ErrorKind::Other,
+        "Unsupported public key type. Only hex-encoded ed25519 public keys are supported. They must start with `ed25519/`.",
+        ))?;
         let bytes =
-            hex::decode(encoded).map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)));
+            hex::decode(hex_key).map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)));
         let pubkey = PublicKey::from_bytes(&bytes?)
             .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
         Ok(Param::PublicKey(name.to_string(), pubkey))
-    } else if let Some(int_str) = value.strip_suffix("::integer") {
-        let int = int_str
+    } else if annotation == Some("integer") {
+        let int = value
             .parse()
             .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
         Ok(Param::Term(name.to_string(), Term::Integer(int)))
-    } else if let Some(date_str) = value.strip_suffix("::date") {
+    } else if annotation == Some("date") {
         let date =
-            time::OffsetDateTime::parse(date_str, &time::format_description::well_known::Rfc3339)
+            time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
                 .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
         let timestamp = date
             .unix_timestamp()
             .try_into()
             .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
         Ok(Param::Term(name.to_string(), Term::Date(timestamp)))
-    } else if let Some(bytes_str) = value.strip_suffix("::bytes") {
+    } else if annotation == Some("bytes") {
+        let hex_bytes = value.strip_prefix("hex:").ok_or_else(|| {
+            Error::new(
+        ErrorKind::Other,
+        "Unusupported byte array literal. Byte arrays must be hex-encoded and start with `hex:`."
+        )
+        })?;
         let bytes =
-            hex::decode(bytes_str).map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
+            hex::decode(hex_bytes).map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
         Ok(Param::Term(name.to_string(), Term::Bytes(bytes)))
-    } else if let Some(bool_str) = value.strip_suffix("::bool") {
-        if bool_str.to_lowercase() == "true" {
+    } else if annotation == Some("bool") {
+        if value.to_lowercase() == "true" {
             Ok(Param::Term(name.to_string(), Term::Bool(true)))
-        } else if bool_str.to_lowercase() == "false" {
+        } else if value.to_lowercase() == "false" {
             Ok(Param::Term(name.to_string(), Term::Bool(false)))
         } else {
             Err(Error::new(
                 ErrorKind::Other,
-                "Boolean params must be either \"true\" or \"false\"",
+                "Boolean params must be either \"true\" or \"false\".",
             ))
         }
-    } else if let Some(value) = value.strip_suffix("::string") {
+    } else if annotation == Some("string") || annotation.is_none() {
         Ok(Param::Term(name.to_string(), Term::Str(value.to_string())))
     } else {
-        Ok(Param::Term(name.to_string(), Term::Str(value.to_string())))
+        Err(Error::new(
+                ErrorKind::Other,
+                "Unsupported parameter type. Supported types are `pubkey`, `string`, `integer`, `date`, `bytes`, or `bool`.",
+            ))
     }
 }
 
@@ -125,13 +144,13 @@ pub struct Generate {
     /// Provide a root key id, as a hint for public key selection
     #[clap(long)]
     pub root_key_id: Option<u32>,
-    /// Provide a value for a datalog parameter. `type` is optional and defaults to `string`. Possible types are pubkey, integer, date, bytes or bool.
-    /// `pubkey` takes a hex-encoded ed25519 key, without the `ed25519/` prefix
-    /// `bytes` takes a hex-encoded byte string, without the `hex:prefix`
+    /// Provide a value for a datalog parameter. `type` is optional and defaults to `string`. Possible types are pubkey, string, integer, date, bytes or bool.
+    /// Bytes values must be hex-encoded and start with `hex:`
+    /// Public keys must be hex-encoded and start with `ed25519/`
     #[clap(
         long,
         value_parser = clap::builder::ValueParser::new(parse_param),
-        value_name = "key=value[::type]"
+        value_name = "key[:type]=value"
     )]
     pub param: Vec<Param>,
     /// Output the biscuit raw bytes directly, with no base64 encoding
@@ -183,11 +202,13 @@ pub struct Attenuate {
     /// Add a TTL check to the generated block (either a RFC3339 datetime or a duration like '1d')
     #[clap(long, parse(try_from_str = parse_ttl))]
     pub add_ttl: Option<Ttl>,
-    /// Provide a value for a datalog parameter
+    /// Provide a value for a datalog parameter. `type` is optional and defaults to `string`. Possible types are pubkey, string, integer, date, bytes or bool.
+    /// Bytes values must be hex-encoded and start with `hex:`
+    /// Public keys must be hex-encoded and start with `ed25519/`
     #[clap(
         long,
         value_parser = clap::builder::ValueParser::new(parse_param),
-        value_name = "key=value::type"
+        value_name = "key[:type]=value"
     )]
     pub param: Vec<Param>,
 }
@@ -293,11 +314,13 @@ pub struct Inspect {
     /// Include the current time in the verifier facts
     #[clap(long)]
     pub include_time: bool,
-    /// Provide a value for a datalog parameter
+    /// Provide a value for a datalog parameter. `type` is optional and defaults to `string`. Possible types are pubkey, string, integer, date, bytes or bool.
+    /// Bytes values must be hex-encoded and start with `hex:`
+    /// Public keys must be hex-encoded and start with `ed25519/`
     #[clap(
         long,
         value_parser = clap::builder::ValueParser::new(parse_param),
-        value_name = "key=value::type",
+        value_name = "key[:type]=value",
         requires("authorize-with"),
         requires("authorize-interactive"),
         requires("authorize-with-file")
@@ -374,11 +397,13 @@ pub struct GenerateThirdPartyBlock {
     /// Add a TTL check to the generated block (either a RFC3339 datetime or a duration like '1d')
     #[clap(long, parse(try_from_str = parse_ttl))]
     pub add_ttl: Option<Ttl>,
-    /// Provide a value for a datalog parameter
+    /// Provide a value for a datalog parameter. `type` is optional and defaults to `string`. Possible types are pubkey, string, integer, date, bytes or bool.
+    /// Bytes values must be hex-encoded and start with `hex:`
+    /// Public keys must be hex-encoded and start with `ed25519/`
     #[clap(
         long,
         value_parser = clap::builder::ValueParser::new(parse_param),
-        value_name = "key=value::type",
+        value_name = "key[:type]=value",
     )]
     pub param: Vec<Param>,
 }


### PR DESCRIPTION
The syntax is now: `--param key:type=value`  (the previous syntax was `--param key=value::type`).


This improves the situation on many counts:

- the type annotation is on the name, not the value. This is more familiar for programming language users. The single colon makes it closer to rust (and idris, for that matter), but removes the nice haskell vibe.
- the type annotation is near the key, not the value, so a typo on the type annotation will likely end up in an error because of mismatching keys, insead of silently passing an unexpected term value
- the type annotation is checked against supported types instead of being silently ignored and passed as part of the value

Additionally, `bool` values are now supported, and `pubkey`/`bytes` literals are now consistent with the datalog syntax itself.

Here are a couple examples of the new syntax

```
❯ echo 'fact({k})'|biscuit generate --private-key-file ../../private.key --param "k:bytes=hex:aabb" - | biscuit inspect -
…
fact(hex:aabb);
…

❯ echo 'fact({k})'|biscuit generate --private-key-file ../../private.key --param "k=test" - | biscuit inspect -
…
fact("test");
…

❯ echo 'fact({k})'|biscuit generate --private-key-file ../../private.key --param "k:yolo=test" - | biscuit inspect -
error: Invalid value "k:yolo=test" for '--param <key[:type]=value>': Unsupported parameter type. Supported types are `pubkey`, `string`, `integer`, `date`, `bytes`, or `bool`.

For more information try --help
Error: error deserializing or verifying the token
```