### PR TITLE
Authorize snapshot

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -193,6 +193,8 @@ pub struct InspectSnapshot {
     #[clap(long)]
     pub raw_input: bool,
     #[clap(flatten)]
+    pub authorization_args: common_args::AuthorizeArgs,
+    #[clap(flatten)]
     pub query_args: common_args::QueryArgs,
     #[clap(flatten)]
     pub param_arg: common_args::ParamArg,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,27 +98,13 @@ pub struct Generate {
 /// Attenuate an existing biscuit by adding a new block
 #[derive(Parser)]
 pub struct Attenuate {
-    /// Read the biscuit from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
-    pub biscuit_file: PathBuf,
-    /// Read the biscuit raw bytes directly, with no base64 parsing
-    #[clap(long)]
-    pub raw_input: bool,
+    #[clap(flatten)]
+    pub biscuit_input_args: common_args::BiscuitInputArgs,
     /// Output the biscuit raw bytes directly, with no base64 encoding
     #[clap(long)]
     pub raw_output: bool,
-    /// The block to append to the token. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
-    #[clap(long)]
-    pub block: Option<String>,
-    /// The block to append to the token. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
-    #[clap(long, parse(from_os_str), conflicts_with = "block")]
-    pub block_file: Option<PathBuf>,
-    /// The optional context string attached to the new block
-    #[clap(long)]
-    pub context: Option<String>,
-    /// Add a TTL check to the generated block (either a RFC3339 datetime or a duration like '1d')
-    #[clap(long, parse(try_from_str = parse_ttl))]
-    pub add_ttl: Option<Ttl>,
+    #[clap(flatten)]
+    pub block_args: common_args::BlockArgs,
     #[clap(flatten)]
     pub param_arg: common_args::ParamArg,
 }
@@ -126,12 +112,8 @@ pub struct Attenuate {
 /// Attenuate an existing biscuit by adding a new third-party block
 #[derive(Parser)]
 pub struct AppendThirdPartyBlock {
-    /// Read the biscuit from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
-    pub biscuit_file: PathBuf,
-    /// Read the biscuit raw bytes directly, with no base64 parsing
-    #[clap(long)]
-    pub raw_input: bool,
+    #[clap(flatten)]
+    pub biscuit_input_args: common_args::BiscuitInputArgs,
     /// Output the biscuit raw bytes directly, with no base64 encoding
     #[clap(long)]
     pub raw_output: bool,
@@ -154,12 +136,8 @@ pub struct AppendThirdPartyBlock {
 /// Inspect a biscuit and optionally check its public key
 #[derive(Parser)]
 pub struct Inspect {
-    /// Read the biscuit from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
-    pub biscuit_file: PathBuf,
-    /// Read the biscuit raw bytes directly, with no base64 parsing
-    #[clap(long)]
-    pub raw_input: bool,
+    #[clap(flatten)]
+    pub biscuit_input_args: common_args::BiscuitInputArgs,
     /// Check the biscuit public key
     #[clap(long, conflicts_with("public-key-file"))]
     pub public_key: Option<String>,
@@ -203,12 +181,8 @@ pub struct InspectSnapshot {
 /// Generate a third-party block request from an existing biscuit
 #[derive(Parser)]
 pub struct GenerateRequest {
-    /// Read the biscuit from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
-    pub biscuit_file: PathBuf,
-    /// Read the biscuit raw bytes directly, with no base64 parsing
-    #[clap(long)]
-    pub raw_input: bool,
+    #[clap(flatten)]
+    pub biscuit_input_args: common_args::BiscuitInputArgs,
     /// Output the request raw bytes directly, with no base64 encoding
     #[clap(long)]
     pub raw_output: bool,
@@ -240,18 +214,8 @@ pub struct GenerateThirdPartyBlock {
     /// Output the block raw bytes directly, with no base64 encoding
     #[clap(long)]
     pub raw_output: bool,
-    /// The block to generate. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
-    #[clap(long)]
-    pub block: Option<String>,
-    /// The block to generate. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
-    #[clap(long, parse(from_os_str), conflicts_with = "block")]
-    pub block_file: Option<PathBuf>,
-    /// The optional context string attached to the new block
-    #[clap(long)]
-    pub context: Option<String>,
-    /// Add a TTL check to the generated block (either a RFC3339 datetime or a duration like '1d')
-    #[clap(long, parse(try_from_str = parse_ttl))]
-    pub add_ttl: Option<Ttl>,
+    #[clap(flatten)]
+    pub block_args: common_args::BlockArgs,
     #[clap(flatten)]
     pub param_arg: common_args::ParamArg,
 }
@@ -259,12 +223,8 @@ pub struct GenerateThirdPartyBlock {
 /// Seal a token, preventing further attenuation
 #[derive(Parser)]
 pub struct Seal {
-    /// Read the biscuit from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
-    pub biscuit_file: PathBuf,
-    /// Read the biscuit raw bytes directly, with no base64 parsing
-    #[clap(long)]
-    pub raw_input: bool,
+    #[clap(flatten)]
+    pub biscuit_input_args: common_args::BiscuitInputArgs,
     /// Output the biscuit raw bytes directly, with no base64 encoding
     #[clap(long)]
     pub raw_output: bool,
@@ -363,5 +323,33 @@ mod common_args {
         /// Include the current time in the verifier facts
         #[clap(long)]
         pub include_time: bool,
+    }
+
+    /// Arguments related to defining a block
+    #[derive(Parser)]
+    pub struct BlockArgs {
+        /// The block to append to the token. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
+        #[clap(long)]
+        pub block: Option<String>,
+        /// The block to append to the token. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
+        #[clap(long, parse(from_os_str), conflicts_with = "block")]
+        pub block_file: Option<PathBuf>,
+        /// The optional context string attached to the new block
+        #[clap(long)]
+        pub context: Option<String>,
+        /// Add a TTL check to the generated block (either a RFC3339 datetime or a duration like '1d')
+        #[clap(long, parse(try_from_str = parse_ttl))]
+        pub add_ttl: Option<Ttl>,
+    }
+
+    /// Arguments related to reading a biscuit
+    #[derive(Parser)]
+    pub struct BiscuitInputArgs {
+        /// Read the biscuit from the given file (or use `-` to read from stdin)
+        #[clap(parse(from_os_str))]
+        pub biscuit_file: PathBuf,
+        /// Read the biscuit raw bytes directly, with no base64 parsing
+        #[clap(long)]
+        pub raw_input: bool,
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,4 +23,6 @@ pub enum CliError {
     InvalidDuration,
     #[error("A public key is required when authorizng a biscuit")]
     MissingPublicKeyForAuthorization,
+    #[error("A public key is required when querying a biscuit")]
+    MissingPublicKeyForQuerying,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,7 +21,7 @@ pub enum CliError {
     ParseError(String, String),
     #[error("Duration outside representable intervals")]
     InvalidDuration,
-    #[error("A public key is required when authorizng a biscuit")]
+    #[error("A public key is required when authorizing a biscuit")]
     MissingPublicKeyForAuthorization,
     #[error("A public key is required when querying a biscuit")]
     MissingPublicKeyForQuerying,

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -98,6 +98,10 @@ pub fn handle_inspect(inspect: &Inspect) -> Result<()> {
         ensure_no_input_conflict(vf, &biscuit_from)?;
     }
 
+    if inspect.query_args.query.is_some() && public_key_from.is_none() {
+        Err(MissingPublicKeyForQuerying)?;
+    }
+
     let biscuit = read_biscuit_from(&biscuit_from)?;
     let is_sealed = is_sealed(&biscuit)?;
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -52,16 +52,19 @@ fn handle_query(
 }
 
 pub fn handle_inspect(inspect: &Inspect) -> Result<()> {
-    let biscuit_format = if inspect.raw_input {
+    let biscuit_format = if inspect.biscuit_input_args.raw_input {
         BiscuitFormat::RawBiscuit
     } else {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if inspect.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if inspect.biscuit_input_args.biscuit_file == PathBuf::from("-") {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
-        BiscuitBytes::FromFile(biscuit_format, inspect.biscuit_file.clone())
+        BiscuitBytes::FromFile(
+            biscuit_format,
+            inspect.biscuit_input_args.biscuit_file.clone(),
+        )
     };
 
     let public_key_from = match (

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,19 +157,25 @@ fn handle_generate(generate: &Generate) -> Result<()> {
 }
 
 fn handle_attenuate(attenuate: &Attenuate) -> Result<()> {
-    let biscuit_format = if attenuate.raw_input {
+    let biscuit_format = if attenuate.biscuit_input_args.raw_input {
         BiscuitFormat::RawBiscuit
     } else {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if attenuate.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if attenuate.biscuit_input_args.biscuit_file == PathBuf::from("-") {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
-        BiscuitBytes::FromFile(biscuit_format, attenuate.biscuit_file.clone())
+        BiscuitBytes::FromFile(
+            biscuit_format,
+            attenuate.biscuit_input_args.biscuit_file.clone(),
+        )
     };
 
-    let block_from = match (&attenuate.block_file, &attenuate.block) {
+    let block_from = match (
+        &attenuate.block_args.block_file,
+        &attenuate.block_args.block,
+    ) {
         (Some(file), None) => DatalogInput::FromFile(file.to_path_buf()),
         (None, Some(str)) => DatalogInput::DatalogString(str.to_owned()),
         (None, None) => DatalogInput::FromEditor,
@@ -185,11 +191,11 @@ fn handle_attenuate(attenuate: &Attenuate) -> Result<()> {
     read_block_from(
         &block_from,
         &attenuate.param_arg.param,
-        &attenuate.context,
+        &attenuate.block_args.context,
         &mut block_builder,
     )?;
 
-    if let Some(ttl) = &attenuate.add_ttl {
+    if let Some(ttl) = &attenuate.block_args.add_ttl {
         block_builder.check_expiration_date(ttl.to_datetime().into());
     }
 
@@ -204,16 +210,19 @@ fn handle_attenuate(attenuate: &Attenuate) -> Result<()> {
 }
 
 fn handle_generate_request(generate_request: &GenerateRequest) -> Result<()> {
-    let biscuit_format = if generate_request.raw_input {
+    let biscuit_format = if generate_request.biscuit_input_args.raw_input {
         BiscuitFormat::RawBiscuit
     } else {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if generate_request.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if generate_request.biscuit_input_args.biscuit_file == PathBuf::from("-") {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
-        BiscuitBytes::FromFile(biscuit_format, generate_request.biscuit_file.clone())
+        BiscuitBytes::FromFile(
+            biscuit_format,
+            generate_request.biscuit_input_args.biscuit_file.clone(),
+        )
     };
 
     let biscuit = read_biscuit_from(&biscuit_from)?;
@@ -248,8 +257,8 @@ fn handle_generate_third_party_block(
     };
 
     let block_from = match (
-        &generate_third_party_block.block_file,
-        &generate_third_party_block.block,
+        &generate_third_party_block.block_args.block_file,
+        &generate_third_party_block.block_args.block,
     ) {
         (Some(file), None) => DatalogInput::FromFile(file.to_path_buf()),
         (None, Some(str)) => DatalogInput::DatalogString(str.to_owned()),
@@ -278,11 +287,11 @@ fn handle_generate_third_party_block(
     read_block_from(
         &block_from,
         &generate_third_party_block.param_arg.param,
-        &generate_third_party_block.context,
+        &generate_third_party_block.block_args.context,
         &mut builder,
     )?;
 
-    if let Some(ttl) = &generate_third_party_block.add_ttl {
+    if let Some(ttl) = &generate_third_party_block.block_args.add_ttl {
         builder.check_expiration_date(ttl.to_datetime().into());
     }
 
@@ -298,20 +307,24 @@ fn handle_generate_third_party_block(
 }
 
 fn handle_append_third_party_block(append_third_party_block: &AppendThirdPartyBlock) -> Result<()> {
-    let biscuit_format = if append_third_party_block.raw_input {
+    let biscuit_format = if append_third_party_block.biscuit_input_args.raw_input {
         BiscuitFormat::RawBiscuit
     } else {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if append_third_party_block.biscuit_file == PathBuf::from("-") {
-        BiscuitBytes::FromStdin(biscuit_format)
-    } else {
-        BiscuitBytes::FromFile(
-            biscuit_format,
-            append_third_party_block.biscuit_file.clone(),
-        )
-    };
+    let biscuit_from =
+        if append_third_party_block.biscuit_input_args.biscuit_file == PathBuf::from("-") {
+            BiscuitBytes::FromStdin(biscuit_format)
+        } else {
+            BiscuitBytes::FromFile(
+                biscuit_format,
+                append_third_party_block
+                    .biscuit_input_args
+                    .biscuit_file
+                    .clone(),
+            )
+        };
 
     let block_file_format = if append_third_party_block.raw_block_contents {
         BiscuitFormat::RawBiscuit
@@ -348,16 +361,16 @@ fn handle_append_third_party_block(append_third_party_block: &AppendThirdPartyBl
 }
 
 fn handle_seal(seal: &Seal) -> Result<()> {
-    let biscuit_format = if seal.raw_input {
+    let biscuit_format = if seal.biscuit_input_args.raw_input {
         BiscuitFormat::RawBiscuit
     } else {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if seal.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if seal.biscuit_input_args.biscuit_file == PathBuf::from("-") {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
-        BiscuitBytes::FromFile(biscuit_format, seal.biscuit_file.clone())
+        BiscuitBytes::FromFile(biscuit_format, seal.biscuit_input_args.biscuit_file.clone())
     };
 
     let biscuit = read_biscuit_from(&biscuit_from)?;


### PR DESCRIPTION
This continues the extraction of common arguments, while adding support for running authorization on a snapshot.