### PR TITLE
feat: JSON output in biscuit inspect-snapshot

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,9 @@ pub struct Inspect {
 /// Inspect a snapshot
 #[derive(Parser)]
 pub struct InspectSnapshot {
+    /// Output the results in a machine-readable format
+    #[clap(long)]
+    pub json: bool,
     /// Read the snapshot from the given file (or use `-` to read from stdin)
     #[clap(parse(from_os_str))]
     pub snapshot_file: PathBuf,


### PR DESCRIPTION
Same as in #48, this allows passing a `--json` flag to `biscuit inspect-snapshot`.

```json
{
  "snapshot": {
    "code": "ou(\"1234\", \"op\");\nuser(\"1234\");\nop(\"op\");\nop(\"op\");\n\nou($u, $o) <- op($o), user($u);\n\nallow if user($u);\n",
    "iterations": 1,
    "elapsed_micros": 120
  },
  "auth": {
    "policies": [
      "allow if user($u)",
      "allow if false"
    ],
    "result": [
      0,
      "allow if user($u)"
    ]
  },
  "query": {
    "query": "data($user) <- user($user)",
    "query_all": false,
    "facts": [
      "data(\"1234\")"
    ]
  }
}
```

`snapshot` is always returned: this is the snapshot contents: `code` contains all the code (more structured info might come later, such as token blocks, etc), while `iterations` and `elapsed_micros` give information about the time already spent computing, and the number of iterations needed to reach a fixpoint.
`auth` and `query` behave the same as in `biscuit inspect`: they are only provided when an authorizer or a query is provided. Note that `auth.policies` contains both the snapshot policies and the policies provided to the command-line.