### PR TITLE
ci: use up-to-date windows image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           rust: nightly
           target: x86_64-apple-darwin
         - build: win-msvc
-          os: windows-2019
+          os: windows-2025
           rust: nightly
           target: x86_64-pc-windows-msvc
             #- build: win-gnu


### PR DESCRIPTION
see https://github.com/actions/runner-images/issues/12045, windows-server-2019 has been retired.