### PR TITLE
Small fixes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,10 +80,10 @@ pub struct KeyPairCmd {
     /// Public and private key output format
     #[clap(long, value_enum, default_value_t)]
     pub key_output_format: KeyFormat,
-    /// Only output the private key
+    /// Only output the public key
     #[clap(long, conflicts_with("only-private-key"))]
     pub only_public_key: bool,
-    /// Only output the public key
+    /// Only output the private key
     #[clap(long, conflicts_with("only-public-key"))]
     pub only_private_key: bool,
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,17 +26,12 @@ pub enum BiscuitFormat {
     Base64Biscuit,
 }
 
-#[derive(PartialEq, Clone, Copy, Debug, ValueEnum)]
+#[derive(PartialEq, Clone, Copy, Debug, Default, ValueEnum)]
 pub enum KeyFormat {
     Raw,
+    #[default]
     Hex,
     Pem,
-}
-
-impl Default for KeyFormat {
-    fn default() -> Self {
-        Self::Hex
-    }
 }
 
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
@@ -581,9 +576,8 @@ pub enum Param {
 }
 
 pub fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
-    use std::io::{Error, ErrorKind};
-    let (binding, value) = (kv.split_once('=').ok_or_else(|| Error::new(
-        ErrorKind::Other,
+    use std::io::Error;
+    let (binding, value) = (kv.split_once('=').ok_or_else(|| Error::other(
         "Params must be `key=value` or `key:type=value` where type is pubkey, string, integer, date, bytes or bool.",
     )))?;
 
@@ -600,28 +594,27 @@ pub fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
       Some("integer") => {
         let int = value
             .parse()
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
+            .map_err(|e| Error::other(format!("{}", &e)))?;
         Ok(Param::Term(name.to_string(), Term::Integer(int)))
       },
       Some("date") => {
         let date =
             time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
-                .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
+                .map_err(|e| Error::other(format!("{}", &e)))?;
         let timestamp = date
             .unix_timestamp()
             .try_into()
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
+            .map_err(|e| Error::other(format!("{}", &e)))?;
         Ok(Param::Term(name.to_string(), Term::Date(timestamp)))
       },
       Some("bytes") => {
         let hex_bytes = value.strip_prefix("hex:").ok_or_else(|| {
-            Error::new(
-        ErrorKind::Other,
+            Error::other(
         "Unusupported byte array literal. Byte arrays must be hex-encoded and start with `hex:`."
         )
         })?;
         let bytes =
-            hex::decode(hex_bytes).map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
+            hex::decode(hex_bytes).map_err(|e| Error::other(format!("{}", &e)))?;
         Ok(Param::Term(name.to_string(), Term::Bytes(bytes)))
       },
       Some("bool") => {
@@ -630,8 +623,7 @@ pub fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
         } else if value.to_lowercase() == "false" {
             Ok(Param::Term(name.to_string(), Term::Bool(false)))
         } else {
-            Err(Error::new(
-                ErrorKind::Other,
+            Err(Error::other(
                 "Boolean params must be either \"true\" or \"false\".",
             ))
         }
@@ -640,8 +632,7 @@ pub fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
         Ok(Param::Term(name.to_string(), Term::Str(value.to_string())))
       },
       _ => {
-        Err(Error::new(
-                ErrorKind::Other,
+        Err(Error::other(
                 "Unsupported parameter type. Supported types are `pubkey`, `string`, `integer`, `date`, `bytes`, or `bool`.",
             ))
       }
@@ -649,7 +640,7 @@ pub fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
 }
 
 pub fn parse_rule(rule: &str) -> Result<Rule, std::io::Error> {
-    use std::io::{Error, ErrorKind};
+    use std::io::Error;
     rule.try_into()
-        .map_err(|e| Error::new(ErrorKind::Other, format!("Could not parse rule: {e}")))
+        .map_err(|e| Error::other(format!("Could not parse rule: {e}")))
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -13,7 +13,6 @@ use biscuit_auth::{
 use chrono::offset::Utc;
 use serde::Serialize;
 use serde_json::json;
-use std::path::PathBuf;
 use std::{fmt::Display, fs};
 
 use crate::cli::*;
@@ -398,7 +397,7 @@ pub fn handle_inspect_inner(inspect: &Inspect) -> Result<InspectionResults> {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if inspect.biscuit_input_args.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if inspect.biscuit_input_args.biscuit_file.as_path() == "-" {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
         BiscuitBytes::FromFile(
@@ -641,7 +640,7 @@ pub fn handle_inspect_snapshot_inner(
         BiscuitFormat::Base64Biscuit
     };
 
-    let snapshot_from = if inspect_snapshot.snapshot_file == PathBuf::from("-") {
+    let snapshot_from = if inspect_snapshot.snapshot_file.as_path() == "-" {
         BiscuitBytes::FromStdin(snapshot_format)
     } else {
         BiscuitBytes::FromFile(snapshot_format, inspect_snapshot.snapshot_file.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn handle_attenuate(attenuate: &Attenuate) -> Result<()> {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if attenuate.biscuit_input_args.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if attenuate.biscuit_input_args.biscuit_file.as_path() == "-" {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
         BiscuitBytes::FromFile(
@@ -237,7 +237,7 @@ fn handle_generate_request(generate_request: &GenerateThirdPartyBlockRequest) ->
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if generate_request.biscuit_input_args.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if generate_request.biscuit_input_args.biscuit_file.as_path() == "-" {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
         BiscuitBytes::FromFile(
@@ -268,7 +268,7 @@ fn handle_generate_third_party_block(
         BiscuitFormat::Base64Biscuit
     };
 
-    let request_from = if generate_third_party_block.request_file == PathBuf::from("-") {
+    let request_from = if generate_third_party_block.request_file.as_path() == "-" {
         BiscuitBytes::FromStdin(block_format)
     } else {
         BiscuitBytes::FromFile(
@@ -345,7 +345,7 @@ fn handle_append_third_party_block(append_third_party_block: &AppendThirdPartyBl
     };
 
     let biscuit_from =
-        if append_third_party_block.biscuit_input_args.biscuit_file == PathBuf::from("-") {
+        if append_third_party_block.biscuit_input_args.biscuit_file.as_path() == "-" {
             BiscuitBytes::FromStdin(biscuit_format)
         } else {
             BiscuitBytes::FromFile(
@@ -398,7 +398,7 @@ fn handle_seal(seal: &Seal) -> Result<()> {
         BiscuitFormat::Base64Biscuit
     };
 
-    let biscuit_from = if seal.biscuit_input_args.biscuit_file == PathBuf::from("-") {
+    let biscuit_from = if seal.biscuit_input_args.biscuit_file.as_path() == "-" {
         BiscuitBytes::FromStdin(biscuit_format)
     } else {
         BiscuitBytes::FromFile(biscuit_format, seal.biscuit_input_args.biscuit_file.clone())


### PR DESCRIPTION
This PR fixes a comments inversion and errors/warnings triggered by Clippy.

All fixes have been validated with tests from #76 and:
```bash
cargo clippy --all-targets --all-features -- -D warnings
```

### 1. IO Error Creation ([`io_other_error`](https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#io_other_error))

Using `Error::new(ErrorKind::Other, ...)` instead of the more concise `Error::other(...)` method introduced in recent Rust versions.

- **Clippy Error:** `this can be std::io::Error::other(_)`

- **Sugestion:** `use std::io::Error::other`

- **Fix:** Replacement of `Error::new(ErrorKind::Other, message)` with `Error::other(message)`.

### 2. Owned Instance Comparison ([`cmp_owned`](https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#cmp_owned))

Inefficient comparison creating a temporary `PathBuf` for each comparison (`PathBuf::from("-")`).

- **Clippy Error:** `warning: this creates an owned instance just for comparison`

- **Suggestion:** `try: inspect.biscuit_input_args.biscuit_file == "-"`

- **Fix:** Using `.as_path() == "-"` for allocation-free comparison, which works because `Path` implements traits for direct comparison with string literals without needing `Path::new()`.

### 1. Derivable Implementation (`derivable_impls`) - 1 occurrence

Manual implementation of `Default` for `KeyFormat` was unnecessary.

- **Clippy Error:** `this impl can be derived`

- **Suggestion:** Replace the manual implementation with a derive attribute and mark the default variant: 

```
30 + #[derive(Default)]
31 ~ pub enum KeyFormat {
32 |     Raw,
33 ~     #[default]
34 ~     Hex,
```

- **Fix:** implement suggestion