### PR TITLE
chore: replace atty by isTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,6 @@ name = "biscuit-cli"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "atty",
  "biscuit-auth",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2.14"
 biscuit-auth = { version = "6.0.0", features = ["serde-error", "pem"] }
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 use anyhow::{bail, Result};
-use atty::Stream;
 use biscuit_auth::{
     builder::{BiscuitBuilder, BlockBuilder, Rule, Term},
     Authorizer, AuthorizerBuilder, PrivateKey, PublicKey, ThirdPartyRequest, UnverifiedBiscuit,
@@ -13,7 +12,7 @@ use chrono::{DateTime, Duration, Utc};
 use clap::{PossibleValue, ValueEnum};
 use parse_duration as duration_parser;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use std::process::Command;
 use std::{collections::HashMap, convert::TryInto};
@@ -123,7 +122,7 @@ pub fn ensure_no_input_conflict_third_party(
 }
 
 pub fn read_stdin_string(desc: &str) -> Result<String> {
-    if atty::is(Stream::Stdin) && atty::is(Stream::Stderr) {
+    if io::stdin().is_terminal() && io::stderr().is_terminal() {
         eprintln!("Please input a {}, followed by <enter> and ^D", &desc);
     }
     let mut buffer = String::new();
@@ -132,7 +131,7 @@ pub fn read_stdin_string(desc: &str) -> Result<String> {
 }
 
 pub fn read_stdin_bytes() -> Result<Vec<u8>> {
-    if atty::is(Stream::Stdin) {
+    if io::stdin().is_terminal() {
         Err(BinaryFromTTY)?
     }
     let mut buffer = Vec::new();
@@ -146,7 +145,7 @@ pub fn read_editor_string() -> Result<String> {
         .tempfile()?;
     let path = &file.path();
 
-    if atty::isnt(Stream::Stdin) || atty::isnt(Stream::Stdout) {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         Err(EditorOutsideTTY)?
     }
 


### PR DESCRIPTION
This PR removes deprecated `atty` by `isTerminal` [as recommended](https://github.com/softprops/atty): 

> This is crate is no longer maintained and users are encouraged to prefer the equivalant functionality of [std.io.IsTerminal](https://doc.rust-lang.org/std/io/trait.IsTerminal.html), introduced in [Rust 1.70.0](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#isterminal)

- Added IsTerminal to the std::io import
- atty::is(Stream::Stdin) → io::stdin().is_terminal()
- atty::isnt(Stream::Stdin) → !io::stdin().is_terminal()
- atty::is(Stream::Stderr) → io::stderr().is_terminal()