### PR TITLE
chore: update clap to 4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,12 +196,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
@@ -223,42 +267,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -454,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -513,16 +564,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -572,14 +617,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
+name = "is_terminal_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -741,16 +782,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "p256"
@@ -826,30 +867,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1009,11 +1026,11 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1158,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1201,23 +1218,8 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -1281,6 +1283,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1369,15 +1377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,12 +1392,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 atty = "0.2.14"
 biscuit-auth = { version = "6.0.0", features = ["serde-error", "pem"] }
-clap = { version = "^3.0", features = ["color", "derive"] }
+clap = { version = "4.5", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"
 parse_duration = "^2.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,27 +43,27 @@ pub enum SubCommand {
 #[clap(display_order(0))]
 pub struct KeyPairCmd {
     /// Generate the keypair from the given private key. If omitted, a random keypair will be generated
-    #[clap(long, value_name("PRIVATE_KEY"), conflicts_with("from-file"))]
+    #[clap(long, value_name = "PRIVATE_KEY", conflicts_with("from_file"))]
     pub from_private_key: Option<String>,
     /// Generate the keypair from a private key stored in the given file (or use `-` to read it from stdin). If omitted, a random keypair will be generated
-    #[clap(long, value_name("PRIVATE_KEY_FILE"))]
+    #[clap(long, value_name = "PRIVATE_KEY_FILE")]
     pub from_file: Option<PathBuf>,
     /// Input format for the private key (when provided).
     #[clap(
         long,
         value_enum,
         default_value_t,
-        value_name("PRIVATE_KEY_FORMAT"),
-        requires("from-private-key"),
-        requires("from-file")
+        value_name = "PRIVATE_KEY_FORMAT",
+        requires("from_private_key"),
+        requires("from_file")
     )]
     pub from_format: KeyFormat,
     /// Specify the private key algorithm, only when reading the private key raw bytes
     #[clap(
         long,
         value_enum,
-        value_name("PRIVATE_KEY_ALGORITHM"),
-        requires("from-file")
+        value_name = "PRIVATE_KEY_ALGORITHM",
+        requires("from_file")
     )]
     pub from_algorithm: Option<Algorithm>,
     /// Key algorithm used when generating a keypair
@@ -71,9 +71,9 @@ pub struct KeyPairCmd {
         long,
         value_enum,
         default_value_t,
-        value_name("KEYPAIR_ALGORITHM"),
-        conflicts_with("from-private-key"),
-        conflicts_with("from-file")
+        value_name = "KEYPAIR_ALGORITHM",
+        conflicts_with("from_private_key"),
+        conflicts_with("from_file")
     )]
     pub key_algorithm: Algorithm,
 
@@ -81,10 +81,10 @@ pub struct KeyPairCmd {
     #[clap(long, value_enum, default_value_t)]
     pub key_output_format: KeyFormat,
     /// Only output the private key
-    #[clap(long, conflicts_with("only-private-key"))]
+    #[clap(long, conflicts_with("only_private_key"))]
     pub only_public_key: bool,
     /// Only output the public key
-    #[clap(long, conflicts_with("only-public-key"))]
+    #[clap(long, conflicts_with("only_public_key"))]
     pub only_private_key: bool,
 }
 
@@ -93,7 +93,7 @@ pub struct KeyPairCmd {
 #[clap(display_order(1))]
 pub struct Generate {
     /// Read the authority block from the given datalog file (or use `-` to read from stdin). If omitted, an interactive $EDITOR will be opened.
-    #[clap(parse(from_os_str), value_name("DATALOG_FILE"))]
+    #[clap(value_name = "DATALOG_FILE")]
     pub authority_file: Option<PathBuf>,
     /// Provide a root key id, as a hint for public key selection
     #[clap(long)]
@@ -113,8 +113,8 @@ pub struct Generate {
     /// [examples: 2025-04-01T00:00:00Z, 1d, 15m]
     #[clap(
         long,
-        parse(try_from_str = parse_ttl),
-        value_name("TTL"),
+        value_parser = clap::builder::ValueParser::new(parse_ttl),
+        value_name = "TTL",
         verbatim_doc_comment
     )]
     pub add_ttl: Option<Ttl>,
@@ -145,16 +145,16 @@ pub struct Inspect {
     #[clap(flatten)]
     pub biscuit_input_args: common_args::BiscuitInputArgs,
     /// Check the biscuit public key
-    #[clap(long, conflicts_with("public-key-file"))]
+    #[clap(long, conflicts_with("public_key_file"))]
     pub public_key: Option<String>,
     /// Check the biscuit public key
-    #[clap(long, conflicts_with("public-key"), parse(from_os_str))]
+    #[clap(long, conflicts_with("public_key"))]
     pub public_key_file: Option<PathBuf>,
     /// Input format for the public key. raw is only available when reading the public key from a file
     #[clap(long, value_enum, default_value_t)]
     pub public_key_format: KeyFormat,
     /// Specify the private key algorithm, only when reading the private key raw bytes
-    #[clap(long, value_enum, requires("public-key-file"))]
+    #[clap(long, value_enum, requires("public_key_file"))]
     pub public_key_algorithm: Option<Algorithm>,
     #[clap(flatten)]
     pub run_limits_args: common_args::RunLimitArgs,
@@ -168,19 +168,19 @@ pub struct Inspect {
     ///
     /// This snapshot will contain the full authorization context, including the biscuit token and the evaluation results. This snapshot only contains the authorization context and does not carry any signatures. It cannot be used in place of a biscuit token.
     /// This is useful to audit the authorization process.
-    #[clap(long, parse(from_os_str), value_name("SNAPSHOT_FILE"))]
+    #[clap(long, value_name = "SNAPSHOT_FILE")]
     pub dump_snapshot_to: Option<PathBuf>,
     /// Output the snapshot raw bytes directly, with no base64 encoding
-    #[clap(long, requires("dump-snapshot-to"))]
+    #[clap(long, requires("dump_snapshot_to"))]
     pub dump_raw_snapshot: bool,
     /// Save a policies snapshot to a file
     ///
     /// This snapshot will only contain the authorizer rules, before the biscuit token is loaded, and before authorization is ran.
     /// This is useful when applying the same authorization rules every time.
-    #[clap(long, parse(from_os_str), value_name("SNAPSHOT_FILE"))]
+    #[clap(long, value_name = "SNAPSHOT_FILE")]
     pub dump_policies_snapshot_to: Option<PathBuf>,
     /// Output the policies snapshot raw bytes directly, with no base64 encoding
-    #[clap(long, requires("dump-snapshot-to"))]
+    #[clap(long, requires("dump_snapshot_to"))]
     pub dump_raw_policies_snapshot: bool,
 }
 
@@ -192,7 +192,6 @@ pub struct InspectSnapshot {
     #[clap(long)]
     pub json: bool,
     /// Read the snapshot from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
     pub snapshot_file: PathBuf,
     /// Read the snapshot raw bytes directly, with no base64 parsing
     #[clap(long)]
@@ -221,7 +220,6 @@ pub struct GenerateThirdPartyBlockRequest {
 #[clap(display_order(6))]
 pub struct GenerateThirdPartyBlock {
     /// Read the request from the given file (or use `-` to read from stdin)
-    #[clap(parse(from_os_str))]
     pub request_file: PathBuf,
     /// Read the request raw bytes directly, with no base64 parsing
     #[clap(long)]
@@ -252,13 +250,12 @@ pub struct AppendThirdPartyBlock {
     /// The third-party block to append to the token
     #[clap(
         long,
-        parse(from_os_str),
-        conflicts_with("block-contents"),
-        required_unless_present("block-contents")
+        conflicts_with("block_contents"),
+        required_unless_present("block_contents")
     )]
     pub block_contents_file: Option<PathBuf>,
     /// Read the third-party block contents raw bytes directly, with no base64 parsing
-    #[clap(long, requires("block-contents-file"))]
+    #[clap(long, requires("block_contents_file"))]
     pub raw_block_contents: bool,
 }
 
@@ -287,7 +284,7 @@ mod common_args {
         #[clap(
           long,
           value_parser = clap::builder::ValueParser::new(parse_rule),
-          value_name("DATALOG_RULE")
+          value_name = "DATALOG_RULE"
         )]
         pub query: Option<Rule>,
         /// Query facts from all blocks (not just authority, authorizer or explicitly trusted blocks). Be careful, this can return untrustworthy facts.
@@ -332,8 +329,8 @@ mod common_args {
         /// [examples: 100ms, 1s]
         #[clap(
             long,
-            parse(try_from_str = parse_duration),
-            value_name("DURATION"),
+            value_parser = clap::builder::ValueParser::new(parse_duration),
+            value_name = "DURATION",
             verbatim_doc_comment
         )]
         pub max_time: Option<Duration>,
@@ -346,57 +343,56 @@ mod common_args {
         #[clap(
             long,
             alias("verify-interactive"),
-            conflicts_with("authorize-with"),
-            conflicts_with("authorize-with-file"),
-            conflicts_with("authorize-with-snapshot"),
-            conflicts_with("authorize-with-snapshot-file")
+            conflicts_with("authorize_with"),
+            conflicts_with("authorize_with_file"),
+            conflicts_with("authorize_with_snapshot"),
+            conflicts_with("authorize_with_snapshot_file")
         )]
         pub authorize_interactive: bool,
         /// Authorize the biscuit with the provided authorizer.
         #[clap(
             long,
-            parse(from_os_str),
             alias("verify-with-file"),
-            conflicts_with("authorize-with"),
-            conflicts_with("authorize-with-snapshot"),
-            conflicts_with("authorize-with-snapshot-file"),
-            conflicts_with("authorize-interactive"),
-            value_name("DATALOG_FILE")
+            conflicts_with("authorize_with"),
+            conflicts_with("authorize_with_snapshot"),
+            conflicts_with("authorize_with_snapshot_file"),
+            conflicts_with("authorize_interactive"),
+            value_name = "DATALOG_FILE"
         )]
         pub authorize_with_file: Option<PathBuf>,
         /// Authorize the biscuit with the provided authorizer
         #[clap(
             long,
             alias("verify-with"),
-            conflicts_with("authorize-with-file"),
-            conflicts_with("authorize-with-snapshot"),
-            conflicts_with("authorize-with-snapshot-file"),
-            conflicts_with("authorize-interactive"),
-            value_name("DATALOG")
+            conflicts_with("authorize_with_file"),
+            conflicts_with("authorize_with_snapshot"),
+            conflicts_with("authorize_with_snapshot_file"),
+            conflicts_with("authorize_interactive"),
+            value_name = "DATALOG"
         )]
         pub authorize_with: Option<String>,
         /// Authorize the biscuit with the provided policies snapshot.
         #[clap(
             long,
-            conflicts_with("authorize-with"),
-            conflicts_with("authorize-with-file"),
-            conflicts_with("authorize-with-snapshot-file"),
-            conflicts_with("authorize-interactive"),
-            value_name("SNAPSHOT")
+            conflicts_with("authorize_with"),
+            conflicts_with("authorize_with_file"),
+            conflicts_with("authorize_with_snapshot_file"),
+            conflicts_with("authorize_interactive"),
+            value_name = "SNAPSHOT"
         )]
         pub authorize_with_snapshot: Option<String>,
         /// Authorize the biscuit with the provided policies snapshot.
         #[clap(
             long,
-            conflicts_with("authorize-with"),
-            conflicts_with("authorize-with-file"),
-            conflicts_with("authorize-with-snapshot"),
-            conflicts_with("authorize-interactive"),
-            value_name("SNAPSHOT_FILE")
+            conflicts_with("authorize_with"),
+            conflicts_with("authorize_with_file"),
+            conflicts_with("authorize_with_snapshot"),
+            conflicts_with("authorize_interactive"),
+            value_name = "SNAPSHOT_FILE"
         )]
         pub authorize_with_snapshot_file: Option<PathBuf>,
         /// Read the snapshot from a binary file
-        #[clap(long, requires("authorize-with-snapshot-file"))]
+        #[clap(long, requires("authorize_with_snapshot_file"))]
         pub authorize_with_raw_snapshot_file: bool,
         /// Include the current time in the verifier facts
         #[clap(long)]
@@ -407,14 +403,13 @@ mod common_args {
     #[derive(Parser)]
     pub struct BlockArgs {
         /// The block to append to the token. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
-        #[clap(long, value_name("DATALOG"))]
+        #[clap(long, value_name = "DATALOG")]
         pub block: Option<String>,
         /// The block to append to the token. If `--block` and `--block-file` are omitted, an interactive $EDITOR will be opened.
         #[clap(
             long,
-            parse(from_os_str),
             conflicts_with = "block",
-            value_name("DATALOG_FILE")
+            value_name = "DATALOG_FILE"
         )]
         pub block_file: Option<PathBuf>,
         /// The optional context string attached to the new block
@@ -425,8 +420,8 @@ mod common_args {
         /// [examples: 2025-04-01T00:00:00Z, 1d, 15m]
         #[clap(
             long,
-            parse(try_from_str = parse_ttl),
-            value_name("TTL"),
+            value_parser = clap::builder::ValueParser::new(parse_ttl),
+            value_name = "TTL",
             verbatim_doc_comment
         )]
         pub add_ttl: Option<Ttl>,
@@ -436,7 +431,6 @@ mod common_args {
     #[derive(Parser)]
     pub struct BiscuitInputArgs {
         /// Read the biscuit from the given file (or use `-` to read from stdin)
-        #[clap(parse(from_os_str))]
         pub biscuit_file: PathBuf,
         /// Read the biscuit raw bytes directly, with no base64 parsing
         #[clap(long)]
@@ -447,14 +441,13 @@ mod common_args {
     #[derive(Parser)]
     pub struct PrivateKeyArgs {
         /// The private key used to sign the block
-        #[clap(long, required_unless_present("private-key-file"))]
+        #[clap(long, required_unless_present("private_key_file"))]
         pub private_key: Option<String>,
         /// The private key used to sign the block
         #[clap(
             long,
-            parse(from_os_str),
-            required_unless_present("private-key"),
-            conflicts_with = "private-key"
+            required_unless_present("private_key"),
+            conflicts_with = "private_key"
         )]
         pub private_key_file: Option<PathBuf>,
         /// Input format for the private key. raw is only available when reading the private key from a file or stdin
@@ -464,8 +457,8 @@ mod common_args {
         #[clap(
             long,
             value_enum,
-            value_name("PRIVATE_KEY_ALGORITHM"),
-            requires("private-key-file")
+            value_name = "PRIVATE_KEY_ALGORITHM",
+            requires("private_key_file")
         )]
         pub private_key_algorithm: Option<Algorithm>,
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -10,7 +10,7 @@ use biscuit_auth::{
     Authorizer, AuthorizerBuilder, PrivateKey, PublicKey, ThirdPartyRequest, UnverifiedBiscuit,
 };
 use chrono::{DateTime, Duration, Utc};
-use clap::{PossibleValue, ValueEnum};
+use clap::{builder::PossibleValue, ValueEnum};
 use parse_duration as duration_parser;
 use std::fs;
 use std::io::{self, Read};
@@ -50,7 +50,7 @@ impl ValueEnum for Algorithm {
         ]
     }
 
-    fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+    fn to_possible_value(&self) -> Option<PossibleValue> {
         Some(PossibleValue::new(match self.0 {
             biscuit_auth::Algorithm::Ed25519 => "ed25519",
             biscuit_auth::Algorithm::Secp256r1 => "secp256r1",
@@ -541,7 +541,7 @@ pub fn append_third_party_from(
     Ok(b)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Ttl {
     Duration(Duration),
     DateTime(DateTime<Utc>),


### PR DESCRIPTION
This PR migrates from Clap 3.2 to Clap 4.5, updating all deprecated APIs and syntax to follow Clap 4.x conventions.

### Core Updates

**Attribute syntax changes:**
- `value_name("FOO")` → `value_name = "FOO"`
- `conflicts_with("foo-bar")` → `conflicts_with("foo_bar")` (underscore naming)
- `requires("foo-bar")` → `requires("foo_bar")`

**Custom parsers:**
- `parse(try_from_str = func)` → `value_parser = clap::builder::ValueParser::new(func)`
- Applied to `parse_ttl`, `parse_duration`, `parse_rule`, and `parse_param`

**Path handling:**
- Removed `parse(from_os_str)` for `PathBuf` arguments (auto-detected in Clap 4)

### Type System Updates

**Import changes:**
- `clap::PossibleValue` → `clap::builder::PossibleValue`

**Trait implementation:**
- `ValueEnum::to_possible_value()` signature simplified (removed explicit lifetime)

**Type derivations:**
- Added `Clone` to `Ttl` enum for `value_parser` compatibility

I've tested this against tests from #76 and a bash script generating outputs of multiple commands to look for any differences. I didn't notice any, except those linked to different Clap 4.x helpers style. 