### PR TITLE
chore: optimize release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,9 @@ anyhow = "1.0.61"
 time = "0.3.13"
 serde_json = "1.0.103"
 serde = { version = "1.0.173", features = ["derive"] }
+
+[profile.release]
+codegen-units = 1     # Better optimization, slower compile
+lto = "fat"           # Link Time Optimization for better performance
+opt-level = "z"       # Optimize for size
+strip = true          # Strip symbols automatically


### PR DESCRIPTION
This PR adds a release profile to reduce binary size. I don't use too agressive options, but if you prefer a different balance between binary size and compile time here are some numbers compared to curent no profile, if we remove `codegen-units` with or witout `lto`:

| Optimization level | Compile time | Binary size |
| ------------------ | ------------ | ----------- |
| No profile         | 19s          | 5.1 MB      |
| Full optimizations | 26s          | 2.2 MB      |
| - codegen          | 24s          | 2.3 MB      |
| - codegen & lto    | 16s          | 3.4 MB      |